### PR TITLE
[Major] Add persistent scheduler for kernel management

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,6 +11,7 @@ tht = "tht"
 SER = "SER"
 pn  = "pn"
 Optin = "Optin"
+ptd = "ptd"
 
 [default]
 check-strings = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -130,7 +130,9 @@
         "__functional_base_03": "cpp",
         "__node_handle": "cpp",
         "__memory": "cpp",
-        "any": "cpp"
+        "any": "cpp",
+        "csignal": "cpp",
+        "regex": "cpp"
     },
     "cmake.cpptools.compilerPath": "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\bin\\nvcc.exe"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,16 @@ set_target_properties(RenderCore PROPERTIES CUDA_SEPARABLE_COMPILATION ON
 target_compile_options(RenderCore
                        PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_FINAL_FLAGS}>)
 
-target_link_libraries(RenderCore PRIVATE tinyxml2 tinyobjloader GLEW::glew glfw Threads::Threads
-                                         imgui ${OPENGL_gl_LIBRARY} max0x7ba::atomic_queue)
+target_link_libraries(
+  RenderCore
+  PRIVATE tinyxml2
+          tinyobjloader
+          GLEW::glew
+          glfw
+          Threads::Threads
+          imgui
+          ${OPENGL_gl_LIBRARY}
+          max0x7ba::atomic_queue)
 
 set(EXEC1_NAME "pt")
 add_executable(${EXEC1_NAME} app/pt_renderer.cu)

--- a/app/pt_renderer.cu
+++ b/app/pt_renderer.cu
@@ -47,8 +47,8 @@ int main(int argc, char **argv) {
     std::cout << "[RENDERER] Path tracer loaded: ";
     switch (scene.rdr_type) {
     case RendererType::MegaKernelPT: {
-        renderer = std::make_unique<PathTracer>(scene);
-        std::cout << "\tMegakernel Path Tracing.\n";
+        renderer = std::make_unique<PathTracer<SingleTileScheduler>>(scene);
+        std::cout << "\tMegakernel Path Tracing (Static Scheduler).\n";
         break;
     }
     case RendererType::WavefrontPT: {
@@ -79,6 +79,13 @@ int main(int argc, char **argv) {
     }
     case RendererType::AcceleratorOnly: {
         std::cout << "\tOnly building (S)BVH accelerator.\n";
+        break;
+    }
+    case RendererType::MegaKernelPTDynamic: {
+        renderer =
+            std::make_unique<PathTracer<PreemptivePersistentTileScheduler>>(
+                scene);
+        std::cout << "\tMegakernel Path Tracing (Dynamic Scheduler).\n";
         break;
     }
     default: {

--- a/app/viewer.cu
+++ b/app/viewer.cu
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     std::cout << "[RENDERER] Path tracer loaded: ";
     switch (scene.rdr_type) {
     case RendererType::MegaKernelPT: {
-        renderer = std::make_unique<PathTracer>(scene);
+        renderer = std::make_unique<PathTracer<SingleTileScheduler>>(scene);
         std::cout << "\tMegakernel Path Tracing.\n";
         break;
     }
@@ -119,6 +119,13 @@ int main(int argc, char **argv) {
     case RendererType::BVHCostViz: {
         renderer = std::make_unique<BVHCostVisualizer>(scene);
         std::cout << "\tBVH Cost Visualizer\n";
+        break;
+    }
+    case RendererType::MegaKernelPTDynamic: {
+        renderer =
+            std::make_unique<PathTracer<PreemptivePersistentTileScheduler>>(
+                scene);
+        std::cout << "\tMegakernel Path Tracing (Dynamic Scheduler).\n";
         break;
     }
     default: {

--- a/src/core/constants.cuh
+++ b/src/core/constants.cuh
@@ -37,3 +37,4 @@ constexpr float M_1_Pi = 1.f / M_Pi;
 constexpr float DEG2RAD = M_Pi / 180.f;
 
 constexpr int INVALID_OBJ = 0xffffffff;
+static constexpr int OCC_BLOCK_PER_SM = 12; // calculated by profiling

--- a/src/core/enums.cuh
+++ b/src/core/enums.cuh
@@ -24,14 +24,15 @@
 #include <stdint.h>
 
 enum RendererType : uint8_t {
-    MegaKernelPT = 0,    // megakernel path tracing
-    WavefrontPT = 1,     // wavefront  path tracing
-    MegaKernelLT = 2,    // megakernel light tracing
-    VoxelSDFPT = 3,      // not supported currently
-    DepthTracing = 4,    // rendering depth map
-    BVHCostViz = 5,      // displaying BVH traversal cost
-    MegaKernelVPT = 6,   // megakernel volumetric path tracer
-    AcceleratorOnly = 7, // Only run accelerator building
+    MegaKernelPT = 0,        // megakernel path tracing
+    WavefrontPT = 1,         // wavefront  path tracing
+    MegaKernelLT = 2,        // megakernel light tracing
+    VoxelSDFPT = 3,          // not supported currently
+    DepthTracing = 4,        // rendering depth map
+    BVHCostViz = 5,          // displaying BVH traversal cost
+    MegaKernelVPT = 6,       // megakernel volumetric path tracer
+    AcceleratorOnly = 7,     // Only run accelerator building
+    MegaKernelPTDynamic = 8, // megakernel path tracing with dynamic scheduling
     NumRendererType
 };
 

--- a/src/impl/scene.cu
+++ b/src/impl/scene.cu
@@ -930,9 +930,9 @@ void parseObjectMediumRef(const tinyxml2::XMLElement *node,
 }
 
 const std::array<std::string, NumRendererType> RENDER_TYPE_STR = {
-    "MegaKernel-PT",  "Wavefront-PT",    "Megakernel-LT",
-    "Voxel-SDF-PT",   "Depth Tracer",    "BVH Cost Visualizer",
-    "MegaKernel-VPT", "Accelerator-Only"};
+    "MegaKernel-PT",  "Wavefront-PT",     "Megakernel-LT",
+    "Voxel-SDF-PT",   "Depth Tracer",     "BVH Cost Visualizer",
+    "MegaKernel-VPT", "Accelerator-Only", "MegaKernel-PT (Dynamic)"};
 
 Scene::Scene(std::string path)
     : num_bsdfs(0), num_emitters(0), num_objects(0), num_prims(0), envmap_id(0),
@@ -976,6 +976,8 @@ Scene::Scene(std::string path)
         render_elem != nullptr ? render_elem->Attribute("type") : "pt";
     if (render_type == "pt")
         rdr_type = RendererType::MegaKernelPT;
+    else if (render_type == "ptd")
+        rdr_type = RendererType::MegaKernelPTDynamic;
     else if (render_type == "wfpt")
         rdr_type = RendererType::WavefrontPT;
     else if (render_type == "lt")

--- a/src/pt_impl/light_tracer.cu
+++ b/src/pt_impl/light_tracer.cu
@@ -41,7 +41,7 @@ CPT_CPU std::vector<uint8_t> LightTracer::render(const MaxDepthParams &md,
         // for more sophisticated renderer (like path tracer), shared_memory
         // should be used
         if (bidirectional) {
-            render_pt_kernel<true>
+            render_pt_kernel<SingleTileScheduler, true>
                 <<<dim3(w >> SHFL_THREAD_X, h >> SHFL_THREAD_Y),
                    dim3(1 << SHFL_THREAD_X, 1 << SHFL_THREAD_Y), cached_size>>>(
                     *camera, verts, norms, uvs, obj_info, emitter_prims,
@@ -72,7 +72,7 @@ CPT_CPU void LightTracer::render_online(const MaxDepthParams &md,
 
     accum_cnt++;
     if (bidirectional) {
-        render_pt_kernel<false>
+        render_pt_kernel<SingleTileScheduler, false>
             <<<dim3(w >> SHFL_THREAD_X, h >> SHFL_THREAD_Y),
                dim3(1 << SHFL_THREAD_X, 1 << SHFL_THREAD_Y), cached_size>>>(
                 *camera, verts, norms, uvs, obj_info, emitter_prims, bvh_leaves,
@@ -96,7 +96,7 @@ CPT_CPU const float *LightTracer::render_raw(const MaxDepthParams &md,
     size_t cached_size = std::max(num_cache * sizeof(uint4), sizeof(uint4));
     accum_cnt++;
     if (bidirectional) {
-        render_pt_kernel<false>
+        render_pt_kernel<SingleTileScheduler, false>
             <<<dim3(w >> SHFL_THREAD_X, h >> SHFL_THREAD_Y),
                dim3(1 << SHFL_THREAD_X, 1 << SHFL_THREAD_Y), cached_size>>>(
                 *camera, verts, norms, uvs, obj_info, emitter_prims, bvh_leaves,

--- a/src/pt_impl/megakernel_pt.cu
+++ b/src/pt_impl/megakernel_pt.cu
@@ -22,11 +22,14 @@
  */
 #include "core/textures.cuh"
 #include "renderer/megakernel_pt.cuh"
+#include "renderer/scheduler.cuh"
 
 static constexpr int RR_BOUNCE = 1;
 static constexpr float RR_THRESHOLD = 0.1;
 
-template <bool render_once>
+__device__ int tile_work_cnt;
+
+template <typename Scheduler, bool render_once>
 CPT_KERNEL void render_pt_kernel(
     const DeviceCamera &dev_cam, const PrecomputedArray verts,
     const NormalArray norms, const ConstBuffer<PackedHalf2> uvs,
@@ -36,14 +39,10 @@ CPT_KERNEL void render_pt_kernel(
     float *__restrict__ output_buffer, float *__restrict__ var_buffer,
     int num_emitter, int seed_offset, int node_num, int accum_cnt,
     int cache_num, int envmap_id, bool gamma_corr) {
-    int px = threadIdx.x + blockIdx.x * blockDim.x,
-        py = threadIdx.y + blockIdx.y * blockDim.y;
 
-    Sampler sampler(px + py * image.w(), seed_offset);
-    // step 1: generate ray
+    __shared__ int tile_smem_cnt;
+    const Scheduler scheduler(&tile_smem_cnt, &tile_work_cnt);
 
-    // step 2: bouncing around the scene until the max depth is reached
-    int min_index = -1, diff_b = 0, spec_b = 0, trans_b = 0;
     int tid = threadIdx.x + threadIdx.y * blockDim.x;
     extern __shared__ uint4 s_cached[];
     // cache near root level BVH nodes for faster traversal
@@ -53,160 +52,168 @@ CPT_KERNEL void render_pt_kernel(
         if (offset_tid < cache_num)
             s_cached[offset_tid] = cached_nodes[offset_tid];
     }
-    Ray ray = dev_cam.generate_ray(px, py, sampler);
     __syncthreads();
 
-    Vec4 throughput(1, 1, 1), radiance(0, 0, 0);
-    float emission_weight = 1.f;
-    bool hit_emitter = false;
+    for (int px = scheduler.get_initial_work(image.w());
+         scheduler.is_valid(px, image.h());
+         px = scheduler.get_next_work(image.w())) {
+        int py = px >> 16;
+        px = px & 0x0000ffff;
 
-    for (int b = 0; b < md_params.max_depth; b++) {
-        float prim_u = 0, prim_v = 0, min_dist = MAX_DIST;
-        int min_object_info = INVALID_OBJ;
-        min_index = -1;
-        // ============= step 1: ray intersection =================
-        min_dist = ray_intersect_bvh(ray, bvh_leaves, nodes, s_cached, verts,
-                                     min_index, min_object_info, prim_u, prim_v,
-                                     node_num, cache_num, min_dist);
+        Sampler sampler(px + py * image.w(), seed_offset);
+        // step 1: generate ray
+        int min_index = -1, diff_b = 0, spec_b = 0, trans_b = 0;
+        Ray ray = dev_cam.generate_ray(px, py, sampler);
 
-        bool is_triangle = true;
-        int object_id = extract_object_info(min_object_info, is_triangle);
+        Vec4 throughput(1, 1, 1), radiance(0, 0, 0);
+        float emission_weight = 1.f;
+        bool hit_emitter = false;
 
-        // ============= step 2: local shading for indirect bounces
-        // ================
-        if (min_index >= 0) {
-            auto it = Primitive::get_interaction(
-                verts, norms, uvs, ray.advance(min_dist), prim_u, prim_v,
-                min_index, is_triangle);
+        // step 2: bouncing around the scene until the max depth is reached
+        for (int b = 0; b < md_params.max_depth; b++) {
+            float prim_u = 0, prim_v = 0, min_dist = MAX_DIST;
+            int min_object_info = INVALID_OBJ;
+            min_index = -1;
+            // ============= step 1: ray intersection =================
+            min_dist = ray_intersect_bvh(
+                ray, bvh_leaves, nodes, s_cached, verts, min_index,
+                min_object_info, prim_u, prim_v, node_num, cache_num, min_dist);
 
-            // ============= step 3: next event estimation ================
-            // (1) randomly pick one emitter
-            int material_id = 0, emitter_id = -1;
-            objects[object_id].unpack(material_id, emitter_id);
-            hit_emitter = emitter_id > 0;
+            bool is_triangle = true;
+            int object_id = extract_object_info(min_object_info, is_triangle);
 
-            // emitter MIS
-            emission_weight =
-                emission_weight /
-                (emission_weight +
-                 objects[object_id].solid_angle_pdf(
-                     c_textures.eval_normal(it, material_id), ray.d, min_dist) *
-                     hit_emitter * (b > 0) * ray.non_delta());
+            // ============= step 2: local shading for indirect bounces
+            if (min_index >= 0) {
+                auto it = Primitive::get_interaction(
+                    verts, norms, uvs, ray.advance(min_dist), prim_u, prim_v,
+                    min_index, is_triangle);
 
-            float direct_pdf = 1; // direct_pdf is the product of
-                                  // light_sampling_pdf and emitter_pdf
-            // (2) check if the ray hits an emitter
-            Vec4 direct_comp =
-                throughput * c_emitter[emitter_id]->eval_le(&ray.d, &it);
-            radiance += direct_comp * emission_weight;
+                // ============= step 3: next event estimation ================
+                // (1) randomly pick one emitter
+                int material_id = 0, emitter_id = -1;
+                objects[object_id].unpack(material_id, emitter_id);
+                hit_emitter = emitter_id > 0;
 
-            Emitter *emitter =
-                sample_emitter(sampler, direct_pdf, num_emitter, emitter_id);
-            // (3) sample a point on the emitter (we avoid sampling the hit
-            // emitter)
-            emitter_id =
-                objects[emitter->get_obj_ref()].sample_emitter_primitive(
-                    sampler.discrete1D(), direct_pdf);
-            emitter_id =
-                emitter_prims[emitter_id]; // extra mapping, introduced after
-                                           // BVH primitive reordering
-            Ray shadow_ray(ray.advance(min_dist), Vec3(0, 0, 0));
-            // use ray.o to avoid creating another shadow_int variable
-            shadow_ray.d =
-                emitter->sample(shadow_ray.o, it.shading_norm, direct_comp,
-                                direct_pdf, sampler.next2D(), verts, norms, uvs,
-                                emitter_id) -
-                shadow_ray.o;
+                // emitter MIS
+                emission_weight = emission_weight /
+                                  (emission_weight +
+                                   objects[object_id].solid_angle_pdf(
+                                       c_textures.eval_normal(it, material_id),
+                                       ray.d, min_dist) *
+                                       hit_emitter * (b > 0) * ray.non_delta());
 
-            float emit_len_mis = shadow_ray.d.length();
-            shadow_ray.d *= __frcp_rn(emit_len_mis); // normalized direction
+                float direct_pdf = 1; // direct_pdf is the product of
+                                      // light_sampling_pdf and emitter_pdf
+                // (2) check if the ray hits an emitter
+                Vec4 direct_comp =
+                    throughput * c_emitter[emitter_id]->eval_le(&ray.d, &it);
+                radiance += direct_comp * emission_weight;
 
-            // (3) NEE scene intersection test (possible warp divergence, but...
-            // nevermind)
-            if (emitter != c_emitter[0] &&
-                occlusion_test_bvh(shadow_ray, bvh_leaves, nodes, s_cached,
-                                   verts, node_num, cache_num,
-                                   emit_len_mis - EPSILON)) {
-                // MIS for BSDF / light sampling, to achieve better rendering
-                // 1 / (direct + ...) is mis_weight direct_pdf / (direct_pdf +
-                // material_pdf), divided by direct_pdf
-                emit_len_mis =
-                    direct_pdf + c_material[material_id]->pdf(
-                                     it, shadow_ray.d, ray.d, material_id) *
-                                     emitter->non_delta();
-                radiance +=
-                    throughput * direct_comp *
-                    c_material[material_id]->eval(it, shadow_ray.d, ray.d,
-                                                  material_id) *
-                    (float(emit_len_mis > EPSILON) *
-                     __frcp_rn(emit_len_mis < EPSILON ? 1.f : emit_len_mis));
-                // numerical guard, in case emit_len_mis is 0
-            }
+                Emitter *emitter = sample_emitter(sampler, direct_pdf,
+                                                  num_emitter, emitter_id);
+                // (3) sample on the emitter (avoid sampling the hit emitter)
+                emitter_id =
+                    objects[emitter->get_obj_ref()].sample_emitter_primitive(
+                        sampler.discrete1D(), direct_pdf);
+                emitter_id =
+                    emitter_prims[emitter_id]; // extra mapping, introduced
+                                               // after BVH primitive reordering
+                Ray shadow_ray(ray.advance(min_dist), Vec3(0, 0, 0));
+                // use ray.o to avoid creating another shadow_int variable
+                shadow_ray.d =
+                    emitter->sample(shadow_ray.o, it.shading_norm, direct_comp,
+                                    direct_pdf, sampler.next2D(), verts, norms,
+                                    uvs, emitter_id) -
+                    shadow_ray.o;
 
-            ScatterStateFlag sampled_lobe = ScatterStateFlag::BSDF_NONE;
-            ray.o = std::move(shadow_ray.o);
-            ray.d = c_material[material_id]->sample_dir(
-                ray.d, it, throughput, emission_weight, sampler, sampled_lobe,
-                material_id);
-            ray.set_delta((ScatterStateFlag::BSDF_SPECULAR & sampled_lobe) > 0);
+                float emit_len_mis = shadow_ray.d.length();
+                shadow_ray.d *= __frcp_rn(emit_len_mis); // normalized direction
 
-            if (radiance.numeric_err())
-                radiance.fill(0);
+                // (3) NEE scene intersection test (possible warp divergence)
+                if (emitter != c_emitter[0] &&
+                    occlusion_test_bvh(shadow_ray, bvh_leaves, nodes, s_cached,
+                                       verts, node_num, cache_num,
+                                       emit_len_mis - EPSILON)) {
+                    // MIS for BSDF / light sampling, to achieve better
+                    // rendering 1 / (direct + ...) is mis_weight direct_pdf /
+                    // (direct_pdf + material_pdf), divided by direct_pdf
+                    emit_len_mis =
+                        direct_pdf + c_material[material_id]->pdf(
+                                         it, shadow_ray.d, ray.d, material_id) *
+                                         emitter->non_delta();
+                    radiance +=
+                        throughput * direct_comp *
+                        c_material[material_id]->eval(it, shadow_ray.d, ray.d,
+                                                      material_id) *
+                        (float(emit_len_mis > EPSILON) *
+                         __frcp_rn(emit_len_mis < EPSILON ? 1.f
+                                                          : emit_len_mis));
+                    // numerical guard, in case emit_len_mis is 0
+                }
 
-            // using BVH enables breaking, since there is no within-loop
-            // synchronization
-            diff_b += (ScatterStateFlag::BSDF_DIFFUSE & sampled_lobe) > 0;
-            spec_b += (ScatterStateFlag::BSDF_SPECULAR & sampled_lobe) > 0;
-            trans_b += (ScatterStateFlag::BSDF_TRANSMIT & sampled_lobe) > 0;
-            if (diff_b >= md_params.max_diffuse ||
-                spec_b >= md_params.max_specular ||
-                trans_b >= md_params.max_tranmit)
-                break;
-            float max_value = throughput.max_elem_3d();
-            if (max_value < THP_EPS)
-                break;
-            if (b >= RR_BOUNCE && max_value < RR_THRESHOLD) {
-                if (sampler.next1D() > max_value)
+                ScatterStateFlag sampled_lobe = ScatterStateFlag::BSDF_NONE;
+                ray.o = std::move(shadow_ray.o);
+                ray.d = c_material[material_id]->sample_dir(
+                    ray.d, it, throughput, emission_weight, sampler,
+                    sampled_lobe, material_id);
+                ray.set_delta((ScatterStateFlag::BSDF_SPECULAR & sampled_lobe) >
+                              0);
+
+                if (radiance.numeric_err())
+                    radiance.fill(0);
+
+                // using BVH enables breaking: no within-loop synchronization
+                diff_b += (ScatterStateFlag::BSDF_DIFFUSE & sampled_lobe) > 0;
+                spec_b += (ScatterStateFlag::BSDF_SPECULAR & sampled_lobe) > 0;
+                trans_b += (ScatterStateFlag::BSDF_TRANSMIT & sampled_lobe) > 0;
+                if (diff_b >= md_params.max_diffuse ||
+                    spec_b >= md_params.max_specular ||
+                    trans_b >= md_params.max_tranmit)
                     break;
-                throughput *= 1. / max_value;
+                float max_value = throughput.max_elem_3d();
+                if (max_value < THP_EPS)
+                    break;
+                if (b >= RR_BOUNCE && max_value < RR_THRESHOLD) {
+                    if (sampler.next1D() > max_value)
+                        break;
+                    throughput *= 1. / max_value;
+                }
+            } else {
+                radiance += throughput * c_emitter[envmap_id]->eval_le(&ray.d);
+                break;
             }
-        } else {
-            radiance += throughput * c_emitter[envmap_id]->eval_le(&ray.d);
-            break;
         }
-    }
-    if constexpr (render_once) {
-        // image will be the output buffer, there will be double buffering
-        auto local_v = image(px, py);
-        if (var_buffer)
-            estimate_variance(var_buffer, local_v, radiance, px, py, image.w(),
-                              accum_cnt);
-        local_v += radiance;
-        image(px, py) = local_v;
-        local_v *= 1.f / float(accum_cnt);
-        local_v = gamma_corr ? local_v.gamma_corr() : local_v;
-        FLOAT4(output_buffer[(px + py * image.w()) << 2]) = float4(local_v);
-    } else {
-        image(px, py) += radiance;
+        if constexpr (render_once) {
+            // image will be the output buffer, there will be double buffering
+            auto local_v = image(px, py);
+            if (var_buffer)
+                estimate_variance(var_buffer, local_v, radiance, px, py,
+                                  image.w(), accum_cnt);
+            local_v += radiance;
+            image(px, py) = local_v;
+            local_v *= 1.f / float(accum_cnt);
+            local_v = gamma_corr ? local_v.gamma_corr() : local_v;
+            FLOAT4(output_buffer[(px + py * image.w()) << 2]) = float4(local_v);
+        } else {
+            image(px, py) += radiance;
+        }
     }
 }
 
-template CPT_KERNEL void render_pt_kernel<true>(
-    const DeviceCamera &dev_cam, const PrecomputedArray verts,
-    const NormalArray norms, const ConstBuffer<PackedHalf2> uvs,
-    ConstObjPtr objects, ConstIndexPtr emitter_prims,
-    const cudaTextureObject_t bvh_leaves, const cudaTextureObject_t nodes,
-    ConstF4Ptr cached_nodes, DeviceImage image, const MaxDepthParams md_params,
-    float *__restrict__ output_buffer, float *__restrict__ var_buffer,
-    int num_emitter, int seed_offset, int node_num, int accum_cnt,
-    int cache_num, int envmap_index, bool gamma_corr);
+#define PRE_CLARE_KERNEL(Scheduler, render_once)                               \
+    template CPT_KERNEL void render_pt_kernel<Scheduler, render_once>(         \
+        const DeviceCamera &dev_cam, const PrecomputedArray verts,             \
+        const NormalArray norms, const ConstBuffer<PackedHalf2> uvs,           \
+        ConstObjPtr objects, ConstIndexPtr emitter_prims,                      \
+        const cudaTextureObject_t bvh_leaves, const cudaTextureObject_t nodes, \
+        ConstF4Ptr cached_nodes, DeviceImage image,                            \
+        const MaxDepthParams md_params, float *__restrict__ output_buffer,     \
+        float *__restrict__ var_buffer, int num_emitter, int seed_offset,      \
+        int node_num, int accum_cnt, int cache_num, int envmap_index,          \
+        bool gamma_corr);
 
-template CPT_KERNEL void render_pt_kernel<false>(
-    const DeviceCamera &dev_cam, const PrecomputedArray verts,
-    const NormalArray norms, const ConstBuffer<PackedHalf2> uvs,
-    ConstObjPtr objects, ConstIndexPtr emitter_prims,
-    const cudaTextureObject_t bvh_leaves, const cudaTextureObject_t nodes,
-    ConstF4Ptr cached_nodes, DeviceImage image, const MaxDepthParams md_params,
-    float *__restrict__ output_buffer, float *__restrict__ var_buffer,
-    int num_emitter, int seed_offset, int node_num, int accum_cnt,
-    int cache_num, int envmap_index, bool gamma_corr);
+PRE_CLARE_KERNEL(SingleTileScheduler, true)
+PRE_CLARE_KERNEL(SingleTileScheduler, false)
+PRE_CLARE_KERNEL(PreemptivePersistentTileScheduler, true)
+PRE_CLARE_KERNEL(PreemptivePersistentTileScheduler, false)
+#undef PRE_CLARE_KERNEL

--- a/src/pyrender/python_render.cu
+++ b/src/pyrender/python_render.cu
@@ -89,9 +89,9 @@ PythonRenderer::PythonRenderer(const nb::str &xml_path, int _device_id,
     std::cout << "[RENDERER] Path tracer loaded: ";
     switch (scene->rdr_type) {
     case RendererType::MegaKernelPT: {
-        rdr = std::make_unique<PathTracer>(*scene);
+        rdr = std::make_unique<PathTracer<SingleTileScheduler>>(*scene);
         rdr->initialize_var_buffer();
-        std::cout << "\tMegakernel Path Tracing.\n";
+        std::cout << "\tMegakernel Path Tracing (Static Scheduler).\n";
         break;
     }
     case RendererType::WavefrontPT: {
@@ -112,7 +112,7 @@ PythonRenderer::PythonRenderer(const nb::str &xml_path, int _device_id,
     }
     case RendererType::MegaKernelVPT: {
         rdr = std::make_unique<VolumePathTracer>(*scene);
-        std::cerr << "\tVolumetric Path Tracer\n";
+        std::cout << "\tVolumetric Path Tracer\n";
         break;
     }
     case RendererType::VoxelSDFPT: {
@@ -123,12 +123,18 @@ PythonRenderer::PythonRenderer(const nb::str &xml_path, int _device_id,
     }
     case RendererType::DepthTracing: {
         rdr = std::make_unique<DepthTracer>(*scene);
-        std::cerr << "\tDepth Tracing\n";
+        std::cout << "\tDepth Tracing\n";
         break;
     }
     case RendererType::BVHCostViz: {
         rdr = std::make_unique<BVHCostVisualizer>(*scene);
-        std::cerr << "\tBVH Cost Visualizer\n";
+        std::cout << "\tBVH Cost Visualizer\n";
+        break;
+    }
+    case RendererType::MegaKernelPTDynamic: {
+        rdr = std::make_unique<PathTracer<PreemptivePersistentTileScheduler>>(
+            *scene);
+        std::cout << "\tMegakernel Path Tracing (Dynamic Scheduler).\n";
         break;
     }
     default: {

--- a/src/renderer/light_tracer.cuh
+++ b/src/renderer/light_tracer.cuh
@@ -28,7 +28,7 @@
 #include <cuda/pipeline>
 #include <cuda_gl_interop.h>
 
-class LightTracer : public PathTracer {
+class LightTracer : public PathTracer<SingleTileScheduler> {
   private:
     bool bidirectional; // whether to use both PT and LT in a single renderer
     int spec_constraint;

--- a/src/renderer/path_tracer.cuh
+++ b/src/renderer/path_tracer.cuh
@@ -29,19 +29,19 @@
 #include <cuda/pipeline>
 #include <cuda_gl_interop.h>
 
-class PathTracer : public TracerBase {
+template <typename Scheduler> class PathTracer : public TracerBase {
   private:
-    bool verbose;
+    const bool verbose;
 
   protected:
     int *_obj_idxs;
     float4 *_nodes;
 
     CompactedObjInfo *obj_info;
-    int num_objs;
-    int num_nodes;
-    int num_cache; // number of cached BVH nodes
-    int num_emitter;
+    const int num_objs;
+    const int num_nodes;
+    const int num_cache; // number of cached BVH nodes
+    const int num_emitter;
     const int envmap_id;
 
     cudaTextureObject_t bvh_leaves;

--- a/src/renderer/scheduler.cuh
+++ b/src/renderer/scheduler.cuh
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 Qianyue He
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License
+// as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General
+// Public License along with this program. If not, see
+//
+//             <https://www.gnu.org/licenses/>.
+
+/**
+ * @author: Qianyue He
+ * @brief Scheduler impl
+ * @date: 2025.10.2
+ */
+#pragma once
+#include "core/cuda_utils.cuh"
+
+extern __device__ int tile_count_ptr[1];
+
+class SingleTileScheduler {
+  public:
+    static constexpr bool is_dynamic = false;
+    CPT_GPU SingleTileScheduler(int *const __restrict__ smem_ptr_ = nullptr,
+                                int *const __restrict__ gmem_ptr_ = nullptr) {}
+
+    CPT_GPU_INLINE int get_initial_work(int width) const {
+        int base = threadIdx.x + blockIdx.x * blockDim.x; // low 16 bit for x
+        base |= (threadIdx.y + blockIdx.y * blockDim.y)
+                << 16; // high 16 bit for y
+        return base;
+    }
+
+    CPT_GPU_INLINE int get_next_work(int width) const { return -1; }
+
+    // pos pass in py
+    CPT_GPU_INLINE bool is_valid(int &pos, int bound = 0) const {
+        return pos >= 0;
+    }
+};
+
+class PreemptivePersistentTileScheduler {
+  private:
+    int *const __restrict__ smem_ptr;
+    int *const __restrict__ gmem_ptr;
+
+    static CPT_CPU_GPU_INLINE void get_coords(int tile_id, int width, int &px,
+                                              int &py) {
+        int wtile_num = (width + 31) >> 5; // + 31 / 32
+        py = tile_id / wtile_num;
+        px = tile_id % wtile_num;
+
+        px = threadIdx.x + px * blockDim.x;
+        py = threadIdx.y + py * blockDim.y;
+    }
+
+  public:
+    static constexpr bool is_dynamic = true;
+
+    CPT_GPU PreemptivePersistentTileScheduler(int *const __restrict__ smem_ptr_,
+                                              int *const __restrict__ gmem_ptr_)
+        : smem_ptr(smem_ptr_), gmem_ptr(gmem_ptr_) {
+        if (blockIdx.x == 0 && blockIdx.y == 0 && threadIdx.x == 0 &&
+            threadIdx.y == 0)
+            *gmem_ptr = gridDim.x * gridDim.y;
+    }
+
+    CPT_GPU_INLINE int get_initial_work(int width) const {
+        int tile_id = blockIdx.x * gridDim.y + blockIdx.y;
+        int py = 0, px = 0;
+        get_coords(tile_id, width, px, py);
+        return (py << 16) | px;
+    }
+
+    CPT_GPU_INLINE int get_next_work(int width) const {
+        if (threadIdx.x == 0 && threadIdx.y == 0) {
+            *smem_ptr = atomicAdd(gmem_ptr, 1);
+        }
+        __syncthreads();
+        int py = 0, px = 0;
+        get_coords(*smem_ptr, width, px, py);
+        return (py << 16) | px;
+    }
+
+    // bound here is height, pass in image.h()
+    CPT_GPU_INLINE bool is_valid(int &pos, int bound = 0) const {
+        // test whether py is in range
+        return (pos >> 16) < ((bound + 3) & 0xfffffffc);
+    }
+};

--- a/src/renderer/volume_pt.cuh
+++ b/src/renderer/volume_pt.cuh
@@ -25,7 +25,7 @@
 #include "core/medium.cuh"
 #include "renderer/path_tracer.cuh"
 
-class VolumePathTracer : public PathTracer {
+class VolumePathTracer : public PathTracer<SingleTileScheduler> {
   protected:
     int cam_vol_id;
     Medium **media;

--- a/src/renderer/wf_path_tracer.cuh
+++ b/src/renderer/wf_path_tracer.cuh
@@ -36,7 +36,7 @@
 #include "core/stats.h"
 #include "renderer/path_tracer.cuh"
 
-class WavefrontPathTracer : public PathTracer {
+class WavefrontPathTracer : public PathTracer<SingleTileScheduler> {
   private:
     PayLoadBufferSoA payload_buffer;
     thrust::device_vector<uint32_t> index_buffer;

--- a/src/viewer_impl/imgui_utils.cu
+++ b/src/viewer_impl/imgui_utils.cu
@@ -35,9 +35,15 @@
 namespace gui {
 
 static constexpr const char *RENDERER_NAMES[] = {
-    "Megakernel Path Tracing",  "Wavefront Path Tracing",
-    "Megakernel Light Tracing", "Voxel-SDF Path Tracing",
-    "Scene Depth Tracing",      "BVH Cost Visualizer"};
+    "Megakernel Path Tracing",
+    "Wavefront Path Tracing",
+    "Megakernel Light Tracing",
+    "Voxel-SDF Path Tracing",
+    "Scene Depth Tracing",
+    "BVH Cost Visualizer",
+    "Megakernel Volumetric Path Tracing",
+    "",
+    "Megakernel Path Tracing (Dynamic)"};
 
 static constexpr std::array<const char *, 4> COLOR_MAP_NAMES = {
     "Jet", "Plasma", "Viridis", "GrayScale"};


### PR DESCRIPTION
Restructure the code into supporting multiple variants of tile schedulers (see `renderer/scheduler.cuh`). The original implementation is equivalent to the `SingleTileScheduler`. While I tried one persistent scheduler `PreemptivePersistentTileScheduler`, there is no speed bonus, since the single tile scheduler is already workload balanced. `PreemptivePersistentTileScheduler` works better in situations with many tiles with different workloads.

- This concludes the TODOs mentioned in #21.

Although the code changes are somewhat heavy, since there is no significant speed bonus, we will only publish a minor version release.